### PR TITLE
Fixed raised issue bug of 113 minesweeper game 

### DIFF
--- a/113 - Minesweeper/script.js
+++ b/113 - Minesweeper/script.js
@@ -25,15 +25,19 @@ function generateMines() {
 
 function handleCellClick(event) {
   const clickedIndex = parseInt(event.target.getAttribute("data-index"));
-  if (mines.includes(clickedIndex)) {
-    revealMines();
-    alert("Game Over! You hit a mine.");
-  } else {
-    revealCell(clickedIndex);
-    points++;
-    updatePoints();
-    if (revealedCells === boardSize * boardSize - totalMines) {
-      alert("Congratulations! You won!");
+  const cell = document.querySelector(`.cell[data-index="${clickedIndex}"]`);
+
+  if (!cell.classList.contains("revealed")) {
+    if (mines.includes(clickedIndex)) {
+      revealMines();
+      alert("Game Over! You hit a mine.");
+    } else {
+      revealCell(clickedIndex);
+      points++;
+      updatePoints();
+      if (revealedCells === boardSize * boardSize - totalMines) {
+        alert("Congratulations! You won!");
+      }
     }
   }
 }


### PR DESCRIPTION

### 🛠️ Fixes Issue  #1380


### 👨‍💻 Changes proposed and Brief Description

I have fixed the error of points count in 113 minesweeper game
On clicking any opened tile again the point remaines constant now

### ✅ Check List (Check all the applicable boxes)

- [ *] My code doesn't break any part of the project
- [* ] This PR does not contain plagiarized content.
- [* ] My Addition/Changes works properly and matches the overall repo pattern.
- [ *] The title of my pull request is a short description of the requested changes.



### 📷 Screenshots

here the initial point count is 2

![image](https://github.com/swapnilsparsh/30DaysOfJavaScript/assets/121503835/a8c3ddd2-1642-4bca-ac2f-3fbef4befa5b)

 and even on clicking the opened tile again it is still 2 instead of increasing by 1 in previous code
 
 
![image](https://github.com/swapnilsparsh/30DaysOfJavaScript/assets/121503835/bab656e7-20e8-40d4-bc83-af74bb8ceec0)
